### PR TITLE
altered css for navbar, signup, login and dashboard routes

### DIFF
--- a/mern-skeleton/client/src/components/NavBar/NavBar.css
+++ b/mern-skeleton/client/src/components/NavBar/NavBar.css
@@ -39,4 +39,5 @@
 
 .NavBar-welcome {
   color: grey;
+  font-size: 12px;
 }

--- a/mern-skeleton/client/src/components/NavBar/NavBar.jsx
+++ b/mern-skeleton/client/src/components/NavBar/NavBar.jsx
@@ -9,26 +9,27 @@ const NavBar = () => {
   let nav = user ?
     <div className='NavBar'>
       <NavLink to='/' className='NavBar-link'><span className='NavBar-logo'>Discogn't</span></NavLink>
-      <div>
+      {/* <div> */}
         <div>
-          <NavLink to='/dashboard' className='NavBar-link'>Dashboard</NavLink>
-          &nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;
+
           <NavLink to='/artists' className='NavBar-link'>ARTISTS</NavLink>
           &nbsp;&nbsp;|&nbsp;&nbsp;
           <NavLink to='/marketplace' className='NavBar-link'>MARKETPLACE</NavLink>
         </div>
         <div>
+        <NavLink to='/dashboard' className='NavBar-link'>DASHBOARD</NavLink>
+        &nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;
           <NavLink to='' className='NavBar-link' onClick={handleLogout}>LOG OUT</NavLink>
           &nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;
-          <span className='NavBar-welcome'>WELCOME, {user.name}</span>
+          <span className='NavBar-welcome'>Welcome, {user.name}</span>
           &nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;
           <NavLink to='/basket' className='NavBar-link' ><span className="material-symbols-outlined">shopping_cart</span></NavLink>
         </div>
-      </div>
+      {/* </div> */}
     </div>
     :
     <div className='NavBar'>
-        <NavLink to='/' className='NavBar-link'><span className='NavBar-logo'>Discogn't</span></NavLink>
+      <NavLink to='/' className='NavBar-link'><span className='NavBar-logo'>Discogn't</span></NavLink>
       <div>
         <NavLink to='/artists' className='NavBar-link'>ARTISTS</NavLink>
         &nbsp;&nbsp;|&nbsp;&nbsp;

--- a/mern-skeleton/client/src/components/SignupForm/SignupForm.css
+++ b/mern-skeleton/client/src/components/SignupForm/SignupForm.css
@@ -1,0 +1,58 @@
+.signup-form-wrapper {
+    background-color: whitesmoke;
+    padding: 10px;
+    border-radius: 5px;
+}
+
+.signup-form-wrapper input {
+    border: 5px;
+    margin: 10px;
+    height: 30px;
+}
+
+.signup-form-wrapper header{
+    margin-left: 10px;
+}
+
+.signup-form-wrapper .submit-group{
+    margin-left: 10px;
+}
+
+.cancel-link {
+    color: #444444;
+    text-decoration: none;
+}
+
+
+
+.signup-button {
+
+    width: 50px;
+    height: 30px;
+    font-size: 12px;
+
+    background: rgb(120, 120, 120);
+    color: whitesmoke;
+
+    outline: none;
+    border: 2px solid;
+    padding: 0px;
+    border-radius: 5px;
+    margin: 0px;
+    transition: 0.5s;
+}
+
+.signup-button span {
+    font-weight: 300;
+
+}
+
+.signup-button:hover {
+    background: rgb(50, 50, 50);
+    transition: 0.5s;
+}
+
+.signup-button:active {
+    transform: scale(0.95) translateY(5px);
+    transition: 0.3s;
+}

--- a/mern-skeleton/client/src/components/SignupForm/SignupForm.jsx
+++ b/mern-skeleton/client/src/components/SignupForm/SignupForm.jsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from "react-router-dom";
 import userService from "../../utils/userService";
 import collection from "../../utils/collection.js";
 import useUser from "../../hooks/useUser";
+import './SignupForm.css'
 
 function SignupForm({ updateMessage }) {
   const navigate = useNavigate();
@@ -54,8 +55,8 @@ function SignupForm({ updateMessage }) {
   };
 
   return (
-    <div>
-      <header className="header-footer">Sign Up</header>
+    <div className="signup-form-wrapper">
+      <header>Sign Up</header>
       <form className="form-horizontal" onSubmit={handleSubmit}>
         <div className="form-group">
           <div className="col-sm-12">
@@ -158,13 +159,13 @@ function SignupForm({ updateMessage }) {
           </div>
         </div>
 
-        <div className="form-group">
+        <div className="submit-group">
           <div className="col-sm-12 text-center">
-            <button className="btn btn-default" disabled={isFormInvalid()}>
+            <button className="signup-button" disabled={isFormInvalid()}>
               Sign Up
             </button>
             &nbsp;&nbsp;
-            <Link to="/">Cancel</Link>
+            <Link to="/" className="cancel-link">Cancel</Link>
           </div>
         </div>
       </form>

--- a/mern-skeleton/client/src/pages/App/App.css
+++ b/mern-skeleton/client/src/pages/App/App.css
@@ -13,5 +13,5 @@
 }
 
 .page-wrapper {
-	margin: 70px 0;
+	margin: 50px 0;
 }

--- a/mern-skeleton/client/src/pages/Dashboard/Billing/Billing.css
+++ b/mern-skeleton/client/src/pages/Dashboard/Billing/Billing.css
@@ -1,15 +1,57 @@
-.billingForm, .creditcard-wrapper {
+.billingForm,
+.creditcard-wrapper {
     display: flex;
     flex-direction: column;
-    width: 50vw;
- margin-top: 10px;
+    width: 35vw;
+    margin-top: 10px;
+    align-items: center;
 }
 
 .billingForm {
-    margin: 50px 0;
+        margin: 0px 0;
+            background-color: whitesmoke;
+            border-radius: 5px;
+}
+
+.billingForm input, select {
+    border: 5px;
+    margin: 10px;
+    height: 30px;
+    width: 90%;
 }
 
 .billingElement {
     margin-top: 10px;
 }
 
+.billing-submit-button {
+
+    width: 50px;
+    height: 30px;
+    font-size: 12px;
+
+    background: rgb(120, 120, 120);
+    color: whitesmoke;
+
+    outline: none;
+    border: 2px solid;
+    padding: 0px;
+    border-radius: 5px;
+    margin-left: 0px;
+    transition: 0.5s;
+}
+
+.billing-submit-button span {
+    font-weight: 300;
+
+}
+
+.billing-submit-button:hover {
+    background: rgb(50, 50, 50);
+    transition: 0.5s;
+}
+
+.billing-submit-button:active {
+    transform: scale(0.95) translateY(5px);
+    transition: 0.3s;
+}

--- a/mern-skeleton/client/src/pages/Dashboard/Billing/Billing.jsx
+++ b/mern-skeleton/client/src/pages/Dashboard/Billing/Billing.jsx
@@ -39,8 +39,8 @@ function Billing() {
                       <input type='text' className='billingElement' placeholder='billing address line 3' value={state.address3} onChange={handleChange} name='address3'></input>
                       <input type='text' className='billingElement' placeholder='billing address zip/postal code' value={state.postcode} onChange={handleChange} name='postcode'></input>
               
-                      <button className='billingElement'>submit</button></div>) :
-            (<button>submit</button>)
+                      <button className='billing-submit-button'>submit</button></div>) :
+                  (<button className='billing-submit-button'>submit</button>)
             }
         </form>   
         </div>

--- a/mern-skeleton/client/src/pages/Dashboard/Dashboard.css
+++ b/mern-skeleton/client/src/pages/Dashboard/Dashboard.css
@@ -11,16 +11,24 @@
     color: whitesmoke;
     height: 100vh;
     width: 25vw;
+    font-weight: 300;
+}
+
+.sidebar-wrapper h3 {
+    font-weight: 300;
+    margin-left: 10px;
 }
 
 .panel-link {
     text-decoration: none;
     color: whitesmoke;
+    margin-left: 10px;
 }
 
 .panel-wrapper {
     display: flex;
     flex-direction: column;
     width: 100vw;
+    margin-top: 40px;
     align-items: center;
 }

--- a/mern-skeleton/client/src/pages/Dashboard/Listings/Listing/Listing.css
+++ b/mern-skeleton/client/src/pages/Dashboard/Listings/Listing/Listing.css
@@ -1,0 +1,66 @@
+.dashboard-listing-wrapper {
+    background-color: whitesmoke;
+    border: 10px;
+    border-radius: 5px;
+    width: 50vw;
+}
+
+.dashboard-listing-wrapper h4 {
+        font-size: 16px;
+        font-weight: 300;
+        padding: 10px;
+        margin: 0px;
+}
+
+
+
+.dashboard-listing-form {
+    display:flex;
+    align-items: center;
+}
+
+.dashboard-listing-input {
+    height: 30px;
+    width: 25%;
+    margin: 10px;
+    border: 5px;
+    border-radius: 5px;
+    /* background-color: rgba(50, 50, 50, 1); */
+    
+}
+
+.dashboard-listing-button {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: center;
+    align-items: center;
+
+    width: 100px;
+    height: 30px;
+    font-size: 14px;
+
+    background: rgb(120, 120, 120);
+    color: whitesmoke;
+
+    outline: none;
+    border: 2px solid;
+    padding: 0px;
+    border-radius: 5px;
+    margin: 10px;
+    transition: 0.5s;
+}
+
+.dashboard-listing-button span {
+    font-weight: 300;
+    /* padding-left: 5px; */
+}
+
+.dashboard-listing-button:hover {
+    background: rgb(50, 50, 50);
+    transition: 0.5s;
+}
+
+.dashboard-listing-button:active {
+    transform: scale(0.95) translateY(5px);
+    transition: 0.3s;
+}

--- a/mern-skeleton/client/src/pages/Dashboard/Listings/Listing/Listing.jsx
+++ b/mern-skeleton/client/src/pages/Dashboard/Listings/Listing/Listing.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import listingService from "../../../../utils/listing";
 import { NavLink } from 'react-router-dom'
 import { useEffect } from "react";
+import './Listing.css'
 
 function Listing(props) {
 
@@ -53,23 +54,23 @@ function Listing(props) {
     console.log(props)
 if (isObjectPopulated(state)) {
     return (
-        <div>
-            <h4>Title: {state.title}</h4>
-            <p>
+        <div className="dashboard-listing-wrapper">
+            <h4>{state.title}</h4>
+            {/* <p>
                 Condition: {state.condition}, price: £{`${state.price}`}, description:{" "}
                 {state.description}
-            </p>
+            </p> */}
             {/* <button onClick={() => handleUpdate(props.listingId)}>Update</button> */}
-            <form onSubmit={handleUpdate}>
-                <input name='condition' type='text' placeholder={`${state.condition}`} value={state.condition} onChange={handleChange} />
-                <input name='price' type='number' placeholder={`${state.price}`} value={state.price} onChange={handleChange} />
-                <textarea name='description' type='text' placeholder={`${state.description}`} value={state.description} onChange={handleChange} />
-                <button>update</button>
+            <form className="dashboard-listing-form" onSubmit={handleUpdate}>
+                <input className="dashboard-listing-input" name='condition' type='text' placeholder={`${state.condition}`} value={state.condition} onChange={handleChange} />
+                <input className="dashboard-listing-input" name='price' type='number' placeholder={`${state.price}`} value={state.price} onChange={handleChange} />
+                <textarea className="dashboard-listing-input" name='description' type='text' placeholder={`${state.description}`} value={state.description} onChange={handleChange} />
+                <button className="dashboard-listing-button"><span>Update</span></button>
             </form>
 
 
 
-            <button onClick={() => handleDelete(props.listingId)}>Delete</button>
+            <button className="dashboard-listing-button" onClick={() => handleDelete(props.listingId)}>Delete</button>
         </div>
     );
 }    

--- a/mern-skeleton/client/src/pages/Dashboard/Security/Security.css
+++ b/mern-skeleton/client/src/pages/Dashboard/Security/Security.css
@@ -1,9 +1,52 @@
 .securityForm, .security-wrapper {
     display: flex;
     flex-direction: column;
-    width: 50vw;
+    width: 35vw;
+    align-items: center;
+    padding: 5px;
 }
 
 .securityForm {
-        margin: 50px 0;
+        margin: 0px 0;
+        background-color: whitesmoke;
+        border-radius: 5px;
+}
+
+.securityForm input {
+border: 5px;
+    margin: 10px;
+    height: 30px;
+    width: 90%;
+}
+
+.security-submit-button {
+
+    width: 50px;
+    height: 30px;
+    font-size: 12px;
+
+    background: rgb(120, 120, 120);
+    color: whitesmoke;
+
+    outline: none;
+    border: 2px solid;
+    padding: 0px;
+    border-radius: 5px;
+    margin-left: 0px;
+    transition: 0.5s;
+}
+
+.security-submit-button span {
+    font-weight: 300;
+
+}
+
+.security-submit-button:hover {
+    background: rgb(50, 50, 50);
+    transition: 0.5s;
+}
+
+.security-submit-button:active {
+    transform: scale(0.95) translateY(5px);
+    transition: 0.3s;
 }

--- a/mern-skeleton/client/src/pages/Dashboard/Security/Security.jsx
+++ b/mern-skeleton/client/src/pages/Dashboard/Security/Security.jsx
@@ -33,9 +33,9 @@ function Security() {
                         <input type='text' placeholder='email' value={state.email} onChange={handleChange} name='email'></input>
                         <input type='text' placeholder='confirm email' value={state.emailConfirm} onChange={handleChange} name='emailConfirm'></input>
                         <input type='text' placeholder='password' value={state.password} onChange={handleChange} name='password'></input>
-                        <input type='text' placeholder='billing address line 1' value={state.passwordConfirm} onChange={handleChange} name='passwordConfirm'></input>
+                        <input type='text' placeholder='confirm password' value={state.passwordConfirm} onChange={handleChange} name='passwordConfirm'></input>
 
-                        <button>submit</button></div>
+                    <button className='security-submit-button'>submit</button></div>
             </form>
         </div>
     )

--- a/mern-skeleton/client/src/pages/LoginPage/LoginPage.css
+++ b/mern-skeleton/client/src/pages/LoginPage/LoginPage.css
@@ -5,3 +5,61 @@
   align-items: center;
   margin: 50px 0;
 }
+
+.login-element-wrapper {
+  background-color: whitesmoke;
+  padding: 10px;
+  border-radius: 5px;
+}
+
+.login-element-wrapper input {
+  border: 5px;
+  margin: 10px;
+  height: 30px;
+}
+
+.login-element-wrapper header {
+  margin-left: 10px;
+}
+
+.login-element-wrapper .submit-group {
+  margin-left: 10px;
+}
+
+.cancel-link {
+  color: #444444;
+  text-decoration: none;
+}
+
+
+.login-button {
+
+  width: 50px;
+  height: 30px;
+  font-size: 12px;
+
+  background: rgb(120, 120, 120);
+  color: whitesmoke;
+
+  outline: none;
+  border: 2px solid;
+  padding: 0px;
+  border-radius: 5px;
+  margin-left: 10px;
+  transition: 0.5s;
+}
+
+.login-button span {
+  font-weight: 300;
+
+}
+
+.login-button:hover {
+  background: rgb(50, 50, 50);
+  transition: 0.5s;
+}
+
+.login-button:active {
+  transform: scale(0.95) translateY(5px);
+  transition: 0.3s;
+}

--- a/mern-skeleton/client/src/pages/LoginPage/LoginPage.jsx
+++ b/mern-skeleton/client/src/pages/LoginPage/LoginPage.jsx
@@ -36,6 +36,7 @@ function LoginPage() {
 
   return (
     <div className="LoginPage">
+      <div className="login-element-wrapper">
       <header className="header-footer">Log In</header>
       <form className="form-horizontal" onSubmit={handleSubmit} >
         <div className="form-group">
@@ -50,11 +51,12 @@ function LoginPage() {
         </div>
         <div className="form-group">
           <div className="col-sm-12 text-center">
-            <button className="btn btn-default">Log In</button>&nbsp;&nbsp;&nbsp;
-            <Link to='/'>Cancel</Link>
+            <button className="login-button">Log In</button>&nbsp;&nbsp;&nbsp;
+            <Link to='/' className='cancel-link'>Cancel</Link>
           </div>
         </div>
       </form>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
In slightly more detail:

Signup login and dashboard routes no longer look completely bare, cribbed button behaviour and colour scheme from listing element

tweaked navbar to put dashboard over with other user related functions (sign out, welcome text)

tweaked page-wrapper top margin from 70px to 50px so that it stopped leaving a bit gap between the dashboard sidebar and the navbar

tweaked font weight on sidebar